### PR TITLE
Fix some references to docs.opendataplane.org

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -14,7 +14,7 @@ columns:
       url: /application-writers/
       items:
         - text: User Guide
-          url : https://docs.opendataplane.org/snapshots/odp-publish/generic/usr_html/master/latest/linux-generic/output/users-guide.html
+          url : /application-writers/users-guide/index.html
         - text: Developers
           url : https://github.com/devicetree-org
     - title: Developers
@@ -26,21 +26,21 @@ columns:
            url : https://www.opendataplane.org/testing/
          - text: Bugs
            url : https://bugs.linaro.org/describecomponents.cgi?product=OpenDataPlane%20-%20linux-%20generic%20reference
-         - text: APIs
-           url : https://docs.opendataplane.org/snapshots/odp-publish/generic/dox_html/master/latest/linux-generic-doxygen-html/index.html
+         - text: API
+           url : /api/index.html
          - text: Implementers Guide
-           url : https://docs.opendataplane.org/snapshots/odp-publish/generic/usr_html/master/latest/linux-generic/output/implementers-guide.html
+           url : /developers/implementers-guide/index.html
          - text: Release Guide
-           url : https://docs.opendataplane.org/snapshots/odp-publish/generic/usr_html/master/latest/linux-generic/output/release-guide.html
+           url : /developers/release-guide/index.html
          - text: Contributing
-           url : https://docs.opendataplane.org/snapshots/odp-publish/generic/usr_html/master/latest/linux-generic/output/CONTRIBUTING.html
+           url : /developers/contributing/index.html
          - text: Bylaws
-           url : https://docs.opendataplane.org/snapshots/odp-publish/generic/usr_html/master/latest/linux-generic/output/bylaws-guide.html
+           url : /developers/bylaws/index.html
     - title: ODP Status
       url: /developers/
       items:
          - text: Change Log
-           url : http://docs.opendataplane.org/snapshots/odp-publish/generic/usr_html/master/latest/linux-generic/output/CHANGELOG.html
+           url : /developers/changelog/index.html
          - text: Bugs
            url : /bugs/
          - text: Git Stats

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -44,7 +44,7 @@ pages:
               url: /developers/release-guide/index.html
             - text: Contributing
               url: /developers/contributing/index.html
-            - text: ByLaws
+            - text: Bylaws
               url: /developers/bylaws/index.html
     - title: Status
       options:

--- a/_data/sub-nav-stacked.yml
+++ b/_data/sub-nav-stacked.yml
@@ -43,7 +43,7 @@ pages:
         url: https://bugs.linaro.org/describecomponents.cgi?product=OpenDataPlane%20-%20linux-%20generic%20reference
         external: true
       -
-        title: APIs
+        title: API
         url: /api/index.html
       -
         title: Implementers Guide

--- a/application-writers/README.md
+++ b/application-writers/README.md
@@ -31,11 +31,11 @@ ODP supports both polling and event driven programming models for packet process
 <h4 class="text-center">odp-linux (Git)</h4>
 </div>
 <div class="col-md-3 col-xs-6 feature" markdown="1">
-{% include image.html name="api_icon.png" alt="API Docs Icon" url="http://docs.opendataplane.org/snapshots/odp-publish/generic/dox_html/master/latest/linux-generic-doxygen-html/index.html" %}
-<h4 class="text-center">API Docs</h4>
+{% include image.html name="api_icon.png" alt="API Docs Icon" url="/api/index.html" %}
+<h4 class="text-center">API Documentation</h4>
 </div>
 <div class="col-md-3 col-xs-6 feature" markdown="1">
-{% include image.html name="user_guide_icon.png" alt="User Guide Icon" url="http://docs.opendataplane.org/snapshots/odp-publish/generic/usr_html/master/latest/linux-generic/output/users-guide.html"%}
+{% include image.html name="user_guide_icon.png" alt="User Guide Icon" url="/application-writers/users-guide/index.html"%}
 <h4 class="text-center">User Guide</h4>
 </div>
 <div class="col-md-3 col-xs-6 feature" markdown="1">

--- a/developers/README.md
+++ b/developers/README.md
@@ -48,7 +48,7 @@ An essential component of ODP is the _Validation Test Suite_. This is a comprehe
         </a>
     </div>
     <div class="col-md-3 col-xs-6 feature">
-        <a href="https://docs.opendataplane.org/snapshots/odp-publish/generic/dox_html/master/latest/linux-generic-doxygen-html/index.html">
+        <a href="/api/index.html">
             <img class="feature-image center-block" src="/assets/images/APIS-icon.png" alt="ODP APIs Icon"/>
         </a>
     </div>


### PR DESCRIPTION
This sorts out the majority of references to the old documentation location. @shovanuk 
