### PR TITLE
Fixed obscure typo stopping 'Git' text from being displayed in nav dr…

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -10,7 +10,7 @@ pages:
               url: /application-writers/
             - text: FAQ
               url: /application-writers/faq/index.html
-            - title: Git
+            - text: Git
               url: https://git.linaro.org/lng/odp.git
               external: true
             - text: API


### PR DESCRIPTION
…opdown

@pcolmer 