### PR TITLE
Removed full URL links to invalid files.

### DIFF
--- a/contributor/corporate/README.md
+++ b/contributor/corporate/README.md
@@ -8,7 +8,7 @@ layout: default-plain
 ## Corporate Contributor
 
 Please download
-**[ODP Corporate Contributor License Agreement](https://www.opendataplane.org/contributor/corporate/ODP-ContributorLicense_Corporate.pdf)** and email the signed copy to legal@linaro.org
+**[ODP Corporate Contributor License Agreement](/contributor/corporate/ODP-ContributorLicense_Corporate.pdf)** and email the signed copy to legal@linaro.org
 
 
 * * *

--- a/contributor/individual/README.md
+++ b/contributor/individual/README.md
@@ -14,7 +14,7 @@ Please read and sign one of the forms below.
 The first document is the hard copy agreement.
 It can be printed, completed, and emailed and/or mailed in to Linaro for record keeping.
 
-[ODP Individual Contributor License Agreement](https://www.opendataplane.org/contributor/individual/ODP-ContributorLicense_Individual.pdf)
+[ODP Individual Contributor License Agreement](/contributor/individual/ODP-ContributorLicense_Individual.pdf)
 
 **Electronically agreement sign**
 


### PR DESCRIPTION
Relative links were not used for PDF's. Therefore the build was looking for a file that did not exist yet.

@shovanuk 