### PR TITLE
Removing reference to /supporters as page currently doesn't exist.

### DIFF
--- a/about/README.md
+++ b/about/README.md
@@ -25,7 +25,7 @@ If you or your company are interested in participating in this effort, please se
 
 The ODP project is managed in a transparent manner. Our weekly meetings are open to the public. Contributors and interested parties are welcome to join us. ODP roadmap plans are discussed at each Linaro Connect [event](http://connect.linaro.org/) (held twice per year). Linaro and its members also host live engineering sprints on an as needed basis, covering specialized topics where intense collaboration benefits the project.
 
-ODP is currently [supported](/supporters/) by over a dozen network hardware and software industry companies. The supporting organizations are generally members of the Linaro Network Group (LNG). Members of LNG also have voting positions on the LNG Steering Committee (LNG-SC). The LNG-SC maintains privileges for overall direction and governance over the ODP project and product road map.
+ODP is currently supported by over a dozen network hardware and software industry companies. The supporting organizations are generally members of the Linaro Network Group (LNG). Members of LNG also have voting positions on the LNG Steering Committee (LNG-SC). The LNG-SC maintains privileges for overall direction and governance over the ODP project and product road map.
 
 You may also find great information in the [OpenDataPlane F.A.Q.](/faq/)
 


### PR DESCRIPTION
The link can be restored once the content is there. Currently, the broken link is causing the site to not build.
