### PR TITLE
Add JSON file for all blog posts

### DIFF
--- a/posts.json.html
+++ b/posts.json.html
@@ -1,0 +1,16 @@
+---
+permalink: /assets/json/posts.json
+---
+func([
+{% for post in site.posts %}
+    {
+        "id": "{{ post.id }}",
+        "title": {{ post.title | smartify | jsonify }},
+        "url": "{{ site.url }}{{ post.url }}",
+        "summary": {{ post.excerpt | smartify | jsonify }},
+        "date_published": "{{ post.date }}",
+        {% if post.author %}"author":"{{post.author}}",{% endif %}
+        "site":"{{site.url}}"
+    }{% unless forloop.last == true %},{% endunless %}
+{% endfor %}
+]);


### PR DESCRIPTION
Add JSON file for all blog posts. This will be used to pull the blog posts in from OpenDataPlane.org and display on Linaro.org/resources/