### PR TITLE
Added the static contact button to replace the Cognito form.

### DIFF
--- a/assets/css/app/custom.scss
+++ b/assets/css/app/custom.scss
@@ -230,3 +230,22 @@ li.side-nav-button:hover {
     margin-top: 50px;
     margin-bottom: 50px;
 } 
+// CSS for the email button.
+#wrapper .email {
+    height: 50px;
+    background-color: $brand-primary;
+    width: 200px;
+    line-height: 30px;
+    text-align: center;
+    color: white;
+    font-weight: bold;
+    border: 1px solid #9e9e9e;
+    margin-left: auto;
+    margin-right: auto;
+    transition: all 200ms ease;
+}
+#wrapper .email:hover {
+    background-color: #3a3a3a;
+    border: 1px solid #000000;
+    color:white;
+}

--- a/contact/README.md
+++ b/contact/README.md
@@ -25,8 +25,11 @@ permalink: /contact/
           </address>
       </div>
       <div class="col-md-8">
-          <iframe src="https://services.cognitoforms.com/f/KvRQmIn2dku6k6gGP711jw?id=4" style="position:relative;width:1px;min-width:100%;*width:100%;" frameborder="0" scrolling="yes" seamless="seamless" height="522" width="100%"></iframe>
-          <script src="https://services.cognitoforms.com/scripts/embed.js"></script>
+            <div class="col-xs-12 text-center">
+                <a class="btn email" href="mailto:contact@linaro.org?subject=OpenDataPlane.org - {{page.url}}">
+                    Contact Us
+                </a>
+            </div>
       </div>
       </div>
     </div>


### PR DESCRIPTION
Added a static contact button on the /contact/ page which replaces the Cognito form. We are moving to a different approach in regards to the website email queries. The new approach uses a mailto: link with a pre-filled subject which is then handled by Service Desk in way whereby any ticket that is created using a set Subject line is assigned to a specific colleague to handle/reassign if needed. This way all emails are tracked and we know when they are being worked on. 