### PR TITLE
Fix download page HTML links

### DIFF
--- a/downloads/README.md
+++ b/downloads/README.md
@@ -27,12 +27,16 @@ of the ODP reference from Git**
 
 <tr id="TR_20">
 <td id="TD_21"> ODP API and Linux generic reference implementation </td>
-<td id="TD_22"> [odp-linux](https://github.com/opendataplane/odp.git) </td>
+<td id="TD_22" markdown="1">
+[odp-linux](https://github.com/OpenDataPlane/odp.git)
+</td>
 </tr>
 
 <tr id="TR_23">
 <td id="TD_24"> ODP implementation utilizing DPDK </td>
-<td id="TD_25"> [odp-dpdk](https://github.com/opendataplane/odp-dpdk.git) </td>
+<td id="TD_25" markdown="1">
+[odp-dpdk](https://github.com/OpenDataPlane/odp-dpdk.git)
+</td>
 </tr>
 
 </tbody>

--- a/downloads/README.md
+++ b/downloads/README.md
@@ -125,20 +125,6 @@ Account Access implementations**
 </tr>
 
 <tr id="TR_90">
-
-<td id="TD_91" markdown="1">
-[![linaro](/assets/images/linaro.png)](http://linaro.org)
-</td>
-
-<td id="TD_94" markdown="1">
-[Link](https://github.com/Linaro/odp-dpdk)
-</td>
-
-<td id="TD_96">ODP-DPDK: SW optimized implementation using DPDK</td>
-
-</tr>
-
-<tr id="TR_90">
 <td id="TD_91" markdown="1">
 [![Marvell](https://www.marvell.com/assets/images/marvell-logo2.svg)](https://www.marvell.com)
 </td>

--- a/downloads/README.md
+++ b/downloads/README.md
@@ -47,8 +47,7 @@ of the ODP reference from Git**
 
 <div class="col-md-6" markdown="1">
 
-**Download other Open and Support
-Account Access implementations**
+**Download other open source implementations of ODP**
 
 <div class="responsive-table">
 


### PR DESCRIPTION
Missing "markdown=1" caused HTML links to not show up correctly. Also cleaned the second download link table.